### PR TITLE
Refactor: Mod 엔티티 Id 생성 전략 변경

### DIFF
--- a/src/main/java/com/feedlink/api/feedlink_api/domain/Hashtag.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/Hashtag.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Hashtag {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long hashtagId;
     private String hashtagName;
     @OneToMany(mappedBy = "hashtag")

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/Hashtag.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/Hashtag.java
@@ -1,0 +1,33 @@
+package com.feedlink.api.feedlink_api.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hastag")
+@Getter
+@NoArgsConstructor
+public class Hashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long hashtagId;
+    private String hashtagName;
+    @OneToMany(mappedBy = "hashtag")
+    private List<PostHashtag> postHashtagList = new ArrayList<>();
+
+    @Builder
+    public Hashtag(Long hashtagId, String hashtagName) {
+        this.hashtagId = hashtagId;
+        this.hashtagName = hashtagName;
+    }
+
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/Hashtag.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/Hashtag.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "hastag")
+@Table(name = "hashtag")
 @Getter
 @NoArgsConstructor
 public class Hashtag {

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/Member.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/Member.java
@@ -1,0 +1,39 @@
+package com.feedlink.api.feedlink_api.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long memberId;
+    @Column(unique = true)
+    private String memberEmail;
+    private String memberPwd;
+    @Column(unique = true)
+    private String memberAccount;
+    private String memberCode;
+    private Boolean memberStatus;
+
+    @Builder
+    public Member(Long memberId, String memberEmail, String memberPwd, String memberAccount,
+        String memberCode, Boolean memberStatus) {
+        this.memberId = memberId;
+        this.memberEmail = memberEmail;
+        this.memberPwd = memberPwd;
+        this.memberAccount = memberAccount;
+        this.memberCode = memberCode;
+        this.memberStatus = memberStatus;
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/Member.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/Member.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Member {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
     @Column(unique = true)
     private String memberEmail;

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/Post.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/Post.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Post {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postId;
     private String postTitle;
     private String postContent;

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/Post.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/Post.java
@@ -1,0 +1,57 @@
+package com.feedlink.api.feedlink_api.domain;
+
+import com.feedlink.api.feedlink_api.enums.PostType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="post")
+@Getter
+@NoArgsConstructor
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long postId;
+    private String postTitle;
+    private String postContent;
+    private Long postViewCnt;
+    private Long postLikeCnt;
+    private Long postShareCnt;
+    private PostType postType;
+    private LocalDateTime postCreateTime;
+    private LocalDateTime postUpdateTime;
+    @OneToMany(mappedBy = "post",cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostHashtag> postHashtagList = new ArrayList<>();
+
+    @Builder
+    public Post(Long postId, String postTitle, String postContent, Long postViewCnt,
+        Long postLikeCnt,
+        Long postShareCnt, PostType postType, LocalDateTime postCreateTime,
+        LocalDateTime postUpdateTime) {
+        this.postId = postId;
+        this.postTitle = postTitle;
+        this.postContent = postContent;
+        this.postViewCnt = postViewCnt;
+        this.postLikeCnt = postLikeCnt;
+        this.postShareCnt = postShareCnt;
+        this.postType = postType;
+        this.postCreateTime = postCreateTime;
+        this.postUpdateTime = postUpdateTime;
+    }
+
+    public void addHashtag(Hashtag hashtag) {
+        PostHashtag postHashtag = PostHashtag.builder().post(this).hashtag(hashtag).build();
+        this.postHashtagList.add(postHashtag);
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/PostHashtag.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/PostHashtag.java
@@ -1,0 +1,38 @@
+package com.feedlink.api.feedlink_api.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post_hashtag")
+@Getter
+@NoArgsConstructor
+public class PostHashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long postHashtagId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="hashtag_id")
+    private Hashtag hashtag;
+
+    @Builder
+    public PostHashtag(Long postHashtagId, Post post, Hashtag hashtag) {
+        this.postHashtagId = postHashtagId;
+        this.post = post;
+        this.hashtag = hashtag;
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/PostHashtag.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/PostHashtag.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PostHashtag {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postHashtagId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/feedlink/api/feedlink_api/enums/PostType.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/enums/PostType.java
@@ -1,0 +1,18 @@
+package com.feedlink.api.feedlink_api.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum PostType {
+    TWITTER("twitter"),
+    FACEBOOK("facebook"),
+    INSTAGRAM("instagram"),
+    THREADS("threads");
+
+    private String value;
+
+    PostType(String value) {
+        this.value = value;
+    }
+}
+


### PR DESCRIPTION
**Create:**
- Member(사용자)
- Post(게시글)
- Hashtag(해시태그)
- PostHashtag(중계)
- PostType(게시글 종류) - enum

---
**Refactor:**
- GenerationType.IDENTITY로 변경
- MySQL의 AUTO_INCREMENT 기능과 호환성을 보장