### PR TITLE
Create 로그인, 로그아웃, 토큰 재발행 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,15 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	//jwt
+	implementation 'com.auth0:java-jwt:4.4.0'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.feedlink.api.feedlink_api.domain.member.controller;
 
+import com.feedlink.api.feedlink_api.domain.member.dto.MemberLoginRequest;
 import com.feedlink.api.feedlink_api.domain.member.dto.MemberSignupRequest;
 import com.feedlink.api.feedlink_api.domain.member.service.MemberService;
 import com.feedlink.api.feedlink_api.global.common.CommonResponse;
@@ -31,4 +32,17 @@ public class MemberController {
         CommonResponse<String> response = memberService.signup(request);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
+
+    /**
+     * 로그인 요청을 처리하는 엔드포인트입니다.
+     *
+     * @param request   이메일,비밀번호를 담은 DTO 객체
+     */
+    @PostMapping("/login")
+    public ResponseEntity<CommonResponse<?>> login(@Valid @RequestBody MemberLoginRequest request){
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+
 }

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/member/controller/MemberController.java
@@ -3,11 +3,14 @@ package com.feedlink.api.feedlink_api.domain.member.controller;
 import com.feedlink.api.feedlink_api.domain.member.dto.MemberLoginRequest;
 import com.feedlink.api.feedlink_api.domain.member.dto.MemberSignupRequest;
 import com.feedlink.api.feedlink_api.domain.member.service.MemberService;
+import com.feedlink.api.feedlink_api.domain.security.PrincipalDetails;
 import com.feedlink.api.feedlink_api.global.common.CommonResponse;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/members")
 @AllArgsConstructor
+@Slf4j
 public class MemberController {
 
     private final MemberService memberService;
@@ -41,6 +45,12 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<CommonResponse<?>> login(@Valid @RequestBody MemberLoginRequest request){
 
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/test")
+    public ResponseEntity<CommonResponse<?>> test(@AuthenticationPrincipal PrincipalDetails member){
+        log.info("member check : {}",member.getMember().getMemberEmail());
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/member/dto/MemberLoginRequest.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/member/dto/MemberLoginRequest.java
@@ -1,0 +1,20 @@
+package com.feedlink.api.feedlink_api.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberLoginRequest {
+
+    @NotBlank(message = "이메일은 필수 입력 값 입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "이메일은 필수 입력 값 입니다.")
+    @Size(min = 10, message = "비밀번호는 최소 10자 이상이어야 합니다.")
+    private String password;
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/member/dto/MemberSigninRequest.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/member/dto/MemberSigninRequest.java
@@ -1,0 +1,2 @@
+package com.feedlink.api.feedlink_api.domain.member.dto;public class MemberSigninRequest {
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/member/dto/MemberSigninRequest.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/member/dto/MemberSigninRequest.java
@@ -1,2 +1,0 @@
-package com.feedlink.api.feedlink_api.domain.member.dto;public class MemberSigninRequest {
-}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByMemberEmailOrMemberAccount(String memberEmail, String MemberAccount);
+
+    Optional<Member> findByMemberEmail(String memberEmail);
 }

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/security/PrincipalDetails.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/security/PrincipalDetails.java
@@ -1,0 +1,57 @@
+package com.feedlink.api.feedlink_api.domain.security;
+
+import com.feedlink.api.feedlink_api.domain.member.entity.Member;
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+@Getter
+public class PrincipalDetails implements UserDetails {
+
+    private final Member member;
+
+    public PrincipalDetails(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getMemberPwd();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getMemberAccount();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+
+    public Long getMemberId() {
+        return member.getMemberId();
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/security/PrincipalDetails.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/security/PrincipalDetails.java
@@ -4,7 +4,6 @@ import com.feedlink.api.feedlink_api.domain.member.entity.Member;
 import java.util.Collection;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.UserDetails;
 @Getter
 public class PrincipalDetails implements UserDetails {
@@ -27,7 +26,7 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return member.getMemberAccount();
+        return member.getMemberEmail();
     }
 
     @Override

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/security/constants/JwtConstants.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/security/constants/JwtConstants.java
@@ -1,0 +1,17 @@
+package com.feedlink.api.feedlink_api.domain.security.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JwtConstants {
+    public static final String SECRET_KEY = "ThisIsServerSecretKey";
+    public static final long ACCESS_EXP_TIME = 60000 * 1;   // 1 분 설정
+    public static final long REFRESH_EXP_TIME = 60000 * 5;   // 5 분 설정
+
+    public static final String JWT_HEADER = "Authorization";
+    public static final String JWT_TYPE = "BEARER ";
+
+    public static final String ACCESS = "AccessToken";
+    public static final String REFRESH = "RefreshToken";
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/security/controller/Controller.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/security/controller/Controller.java
@@ -1,0 +1,29 @@
+package com.feedlink.api.feedlink_api.domain.security.controller;
+
+import com.feedlink.api.feedlink_api.domain.security.dto.ReissueRequest;
+import com.feedlink.api.feedlink_api.domain.security.service.SecurityService;
+import com.feedlink.api.feedlink_api.global.common.CommonResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/security")
+@AllArgsConstructor
+public class Controller {
+
+    private final SecurityService securityService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<CommonResponse<String>> reissue(@RequestBody ReissueRequest reissueRequest) {
+        String token = securityService.reissue(reissueRequest);
+        return new ResponseEntity<>(CommonResponse.ok(token), HttpStatus.CREATED) ;
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/security/dto/ReissueRequest.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/security/dto/ReissueRequest.java
@@ -1,0 +1,16 @@
+package com.feedlink.api.feedlink_api.domain.security.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NonNull;
+
+@Getter
+public class ReissueRequest {
+
+    @NotBlank(message = "refreshToken는 필수 값 입니다.")
+    private String refreshToken;
+
+    @NotBlank(message = "accessToken는 필수 값 입니다.")
+    private String accessToken;
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/security/service/SecurityService.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/security/service/SecurityService.java
@@ -5,6 +5,7 @@ import static com.feedlink.api.feedlink_api.global.error.ErrorCode.LOGIN_FAIL;
 import com.feedlink.api.feedlink_api.domain.member.entity.Member;
 import com.feedlink.api.feedlink_api.domain.member.repository.MemberRepository;
 import com.feedlink.api.feedlink_api.domain.security.PrincipalDetails;
+import com.feedlink.api.feedlink_api.domain.security.dto.ReissueRequest;
 import com.feedlink.api.feedlink_api.global.security.autheniation.token.TokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +31,8 @@ public class SecurityService implements UserDetailsService {
         return new PrincipalDetails(member);
     }
 
-//    public String reissue(ReissueRequest reissueRequest) {
-//        return tokenService.reissueToken(reissueRequest.refreshToken(), reissueRequest.accessToken());
-//    }
+    public String reissue(ReissueRequest reissueRequest) {
+        return tokenService.reissueToken(reissueRequest.getRefreshToken(),
+            reissueRequest.getAccessToken());
+    }
 }

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/security/service/SecurityService.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/security/service/SecurityService.java
@@ -1,0 +1,36 @@
+package com.feedlink.api.feedlink_api.domain.security.service;
+
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.LOGIN_FAIL;
+
+import com.feedlink.api.feedlink_api.domain.member.entity.Member;
+import com.feedlink.api.feedlink_api.domain.member.repository.MemberRepository;
+import com.feedlink.api.feedlink_api.domain.security.PrincipalDetails;
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.TokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SecurityService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+    private final TokenService tokenService;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByMemberEmail(username)
+            .orElseThrow(() -> new UsernameNotFoundException(LOGIN_FAIL.getMessage()));
+
+        log.info("LoadMember member = {}", member);
+        return new PrincipalDetails(member);
+    }
+
+//    public String reissue(ReissueRequest reissueRequest) {
+//        return tokenService.reissueToken(reissueRequest.refreshToken(), reissueRequest.accessToken());
+//    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/security/utils/JwtUtils.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/security/utils/JwtUtils.java
@@ -1,0 +1,70 @@
+package com.feedlink.api.feedlink_api.domain.security.utils;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.feedlink.api.feedlink_api.domain.member.entity.Member;
+import com.feedlink.api.feedlink_api.domain.security.constants.JwtConstants;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JwtUtils {
+
+    // Access Token 에는 id를 담는다
+    public static String generateAccessToken(Member member) {
+
+        return JWT.create()
+            .withSubject(JwtConstants.ACCESS)
+            .withHeader(createHeader())
+            .withClaim("id", member.getMemberId())
+            .withExpiresAt(createExpireDate(JwtConstants.ACCESS_EXP_TIME))
+            .sign(Algorithm.HMAC512(JwtConstants.SECRET_KEY));
+    }
+
+    // Refresh Token 에는 아무것도 담지 않는다
+    public static String generateRefreshToken(Member member) {
+        return JWT.create()
+            .withSubject(JwtConstants.REFRESH)
+            .withHeader(createHeader())
+            .withExpiresAt(createExpireDate(JwtConstants.REFRESH_EXP_TIME))
+            .sign(Algorithm.HMAC512(JwtConstants.SECRET_KEY));
+    }
+
+    // 헤더 정보 생성
+    private static Map<String, Object> createHeader() {
+        Map<String, Object> header = new HashMap<>();
+        header.put("typ", "JWT");
+        header.put("alg", "HS512");
+        return header;
+    }
+
+    // 만료 시간 생성
+    private static Date createExpireDate(long expireTime) {
+        return new Date(System.currentTimeMillis() + expireTime);
+    }
+
+
+    // 헤더에 Bearer XXX 형식으로 담겨온 토큰을 추출한다
+    public static String getTokenFromHeader(String header) {
+        return header.split(" ")[1];
+    }
+
+
+    // 토큰 유효성 검사 => 여러 예외가 발생함 ( 호출하는 곳에서 처리 필요 )
+    public static DecodedJWT verifyToken(String token) {
+        return JWT.require(Algorithm.HMAC512(JwtConstants.SECRET_KEY)).build().verify(token);
+    }
+
+    public static UsernamePasswordAuthenticationToken getAuthenticationToken(DecodedJWT decodedJWT) {
+        String id = decodedJWT.getClaim("id").asString();
+
+        return new UsernamePasswordAuthenticationToken(id, null);
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/common/CommonResponse.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/common/CommonResponse.java
@@ -21,4 +21,13 @@ public class CommonResponse<T> {
     public static <T> CommonResponse<T> ok(String message, T data) {
         return new CommonResponse<>(HttpStatus.OK, message, data);
     }
+
+    public static CommonResponse<Void> fail(String message) {
+        return fail(message, null);
+    }
+
+    public static <T> CommonResponse<T> fail(String message, T data) {
+        return new CommonResponse<>(HttpStatus.UNAUTHORIZED, message, data);
+    }
+
 }

--- a/src/main/java/com/feedlink/api/feedlink_api/global/config/SecurityConfig.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
         http
             .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
-                    "/api/members/signup", "/api/members/login", "/api/members/logout")
+                    "/api/members/signup", "/api/members/login", "/api/members/logout",
+                    "/api/security/reissue")
                 .permitAll() // Swagger 관련 경로 허용
                 .anyRequest().authenticated() // 나머지 모든 요청은 인증 필요
             )

--- a/src/main/java/com/feedlink/api/feedlink_api/global/config/SecurityConfig.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/config/SecurityConfig.java
@@ -1,31 +1,107 @@
 package com.feedlink.api.feedlink_api.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.feedlink.api.feedlink_api.global.security.autheniation.LoginAuthenticationConfigurer;
+import com.feedlink.api.feedlink_api.global.security.autheniation.LoginAuthenticationFailureHandler;
+import com.feedlink.api.feedlink_api.global.security.autheniation.LoginAuthenticationFilter;
+import com.feedlink.api.feedlink_api.global.security.autheniation.LoginAuthenticationSuccessHandler;
+import com.feedlink.api.feedlink_api.global.security.autheniation.LogoutTokenHandler;
+import com.feedlink.api.feedlink_api.global.security.autheniation.LogoutTokenSuccessHandler;
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.TokenService;
+import com.feedlink.api.feedlink_api.global.security.authorization.SecurityAccessDeniedHandler;
+import com.feedlink.api.feedlink_api.global.security.authorization.SecurityAuthenticationEntryPoint;
+import com.feedlink.api.feedlink_api.global.security.authorization.TokenAuthorityConfigurer;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 
+@RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
+
+    private final ObjectMapper objectMapper;
+    private final UserDetailsService userDetailsService;
+    private final TokenService tokenService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
-                    "/api/members/signup").permitAll() // Swagger 관련 경로 허용
+                    "/api/members/signup", "/api/members/login", "/api/members/logout")
+                .permitAll() // Swagger 관련 경로 허용
                 .anyRequest().authenticated() // 나머지 모든 요청은 인증 필요
             )
             .csrf(csrf -> csrf.disable()) // 전체 CSRF 비활성화
             .formLogin(formLogin -> formLogin.disable())  // 폼 로그인을 비활성화
-            .httpBasic(httpBasic -> httpBasic.disable());  // HTTP Basic 인증을 비활성화
+            .httpBasic(httpBasic -> httpBasic.disable())  // HTTP Basic 인증을 비활성화
+            .logout(
+                logoutConfigurer -> logoutConfigurer
+                    .logoutUrl("/api/members/logout")
+                    .addLogoutHandler(createLogoutHandler())
+                    .logoutSuccessHandler(createLogoutSuccessHandler())
+            )
+            .with(
+                new LoginAuthenticationConfigurer<>(createAuthenticationFilter()),
+                SecurityAuthenticationFilter -> SecurityAuthenticationFilter
+                    .successHandler(createAuthenticationSuccessHandler())
+                    .failureHandler(createAuthenticationFailureHandler()))
+            .with(
+                new TokenAuthorityConfigurer(tokenService, userDetailsService),
+                Customizer.withDefaults()
+            )
+            .exceptionHandling(
+                exceptionHandling -> exceptionHandling
+                    .accessDeniedHandler(createAccessDeniedHandler())
+                    .authenticationEntryPoint(createAuthenticationEntryPoint())
+            );
 
-        return  http.build();
+        return http.build();
     }
-        @Bean
-    public PasswordEncoder passwordEncoder() {
+
+    @Bean
+    public static PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    private LogoutHandler createLogoutHandler() {
+        return new LogoutTokenHandler(objectMapper, tokenService);
+    }
+
+    private LogoutSuccessHandler createLogoutSuccessHandler() {
+        return new LogoutTokenSuccessHandler(objectMapper);
+    }
+
+    private AbstractAuthenticationProcessingFilter createAuthenticationFilter() {
+        return new LoginAuthenticationFilter(objectMapper);
+    }
+
+    private AuthenticationSuccessHandler createAuthenticationSuccessHandler() {
+        return new LoginAuthenticationSuccessHandler(objectMapper, tokenService);
+    }
+
+    private AuthenticationFailureHandler createAuthenticationFailureHandler() {
+        return new LoginAuthenticationFailureHandler(objectMapper);
+    }
+
+    private AccessDeniedHandler createAccessDeniedHandler() {
+        return new SecurityAccessDeniedHandler();
+    }
+
+    private AuthenticationEntryPoint createAuthenticationEntryPoint() {
+        return new SecurityAuthenticationEntryPoint(objectMapper);
     }
 }

--- a/src/main/java/com/feedlink/api/feedlink_api/global/error/ErrorCode.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/error/ErrorCode.java
@@ -1,12 +1,19 @@
 package com.feedlink.api.feedlink_api.global.error;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
+
+    //공통
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
+    COMMON_SYSTEM_ERROR(INTERNAL_SERVER_ERROR, "시스템 오류입니다."),
+
 
     //회원가입
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
@@ -17,8 +24,19 @@ public enum ErrorCode {
     PASSWORD_LACKS_VARIETY(HttpStatus.BAD_REQUEST, "숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다."),
     PASSWORD_SIMILAR_TO_PERSONAL_INFO(HttpStatus.BAD_REQUEST, "비밀번호는 다른 개인 정보와 유사할 수 없습니다."),
     PASSWORD_SAME_AS_PREVIOUS(HttpStatus.BAD_REQUEST, "이전 비밀번호와 동일하게 설정할 수 없습니다."),
-    PASSWORD_HAS_SEQUENTIAL_CHARS(HttpStatus.BAD_REQUEST, "3회 이상 연속되는 문자는 사용할 수 없습니다.");
+    PASSWORD_HAS_SEQUENTIAL_CHARS(HttpStatus.BAD_REQUEST, "3회 이상 연속되는 문자는 사용할 수 없습니다."),
 
+    //로그인
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
+    EMPTY_SUCCESS_HANDLER(INTERNAL_SERVER_ERROR, "SuccessHandler 필수 값 입니다."),
+    EMPTY_FAILURE_HANDLER(INTERNAL_SERVER_ERROR, "FailureHandler 필수 값 입니다."),
+    LOGIN_FAIL(BAD_REQUEST, "이메일, 비밀번호를 확인해주세요."),
+    INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰 입니다."),
+    SAVE_REFRESH_TOKEN_FAILED(UNAUTHORIZED, "Token 저장 중 오류가 발생 했습니다."),
+    EMPTY_REFRESH_TOKEN(BAD_REQUEST, "Refresh Token은 필수 값 입니다."),
+    EMPTY_ACCESS_TOKEN(BAD_REQUEST, "Access Token은 필수 값 입니다."),
+    LOGOUT_ACCESS_TOKEN(UNAUTHORIZED, "로그아웃 된 토큰입니다."),
+    EXPIRED_TOKEN(UNAUTHORIZED, "만료된 토큰 입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/feedlink/api/feedlink_api/global/exception/CustomException.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/exception/CustomException.java
@@ -13,4 +13,9 @@ public class CustomException extends RuntimeException {
         this.errorCode = errorCode;
         this.message = errorCode.getMessage();
     }
+
+    public CustomException(String message, ErrorCode errorCode){
+        this.message = message;
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/feedlink/api/feedlink_api/global/redis/RedisConfig.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/redis/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.feedlink.api.feedlink_api.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        log.info("Connect to Redis");
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/redis/RedisService.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/redis/RedisService.java
@@ -1,0 +1,96 @@
+package com.feedlink.api.feedlink_api.global.redis;
+
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.COMMON_SYSTEM_ERROR;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.feedlink.api.feedlink_api.global.exception.CustomException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * key로 데이터를 조회하고, type으로 지정된 객체 타입으로 변환해서 반환합니다.
+     *
+     * @param key       저장된 key값
+     * @param type      변환하려는 객체 타입
+     * @return  저장된 key의 값을 원하는 객체 타입으로 변환하여 반환
+     * */
+    public <T> Optional<T> get(String key, Class<T> type) {
+        log.info("Find Redis Key = [{}], Type = [{}]", key, type.getName());
+        String serializedValue = redisTemplate.opsForValue().get(key);
+
+        try {
+            return Optional.of(objectMapper.readValue(serializedValue, type));
+        } catch (IllegalArgumentException | InvalidFormatException e) {
+            return Optional.empty();
+        } catch (Exception e) {
+            log.error("Redis Get Exception", e);
+            throw new CustomException("Redis get() Error", COMMON_SYSTEM_ERROR);
+        }
+    }
+
+    /**
+     * redis에 데이터를 저장합니다.
+     *
+     * @param key           저장될 key값
+     * @param value         저장하려는 데이터
+     * @param expiredTime   데이터 만료시간
+     * */
+    public void set(String key, Object value, Long expiredTime) {
+        log.info("Save Redis Key = [{}], Value = [{}], expiredTime = [{}]", key, value, expiredTime);
+        try {
+            String serializedValue = objectMapper.writeValueAsString(value);
+            redisTemplate.opsForValue().set(key, serializedValue, expiredTime, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.error("Redis Set Exception", e);
+            throw new CustomException("Redis get() Error", COMMON_SYSTEM_ERROR);
+        }
+    }
+
+    /**
+     * Redis에 데이터 저장 성공 여부를 확인합니다.
+     *
+     * @param key           저장될 key값
+     * @param value         저장하려는 데이터
+     * @param expiredTime   데이터 만료시간
+     * @return              저장 성공 여부를 나타내는 boolean 값
+     * */
+    public boolean setIfAbsent(String key, Object value, Long expiredTime) {
+        log.info("Save If Absent Redis Key = [{}], Value = [{}], expiredTime = [{}]", key, value, expiredTime);
+        try {
+            String serializedValue = objectMapper.writeValueAsString(value);
+            return Boolean.TRUE.equals(
+                redisTemplate.opsForValue().setIfAbsent(
+                    key,
+                    serializedValue,
+                    expiredTime, TimeUnit.SECONDS
+                ));
+        } catch (Exception e) {
+            log.error("Redis Set Exception", e);
+            throw new CustomException("Redis get() Error", COMMON_SYSTEM_ERROR);
+        }
+    }
+
+    /**
+     * 저장된 데이터를 삭제합니다..
+     *
+     * @param key   삭제할 데이터의 key값
+     * @return      삭제 성공 여부를 나타내는 boolean 값
+     */
+    public boolean delete(String key) {
+        log.info("Delete Redis Key = [{}]", key);
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LoginAuthenticationConfigurer.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LoginAuthenticationConfigurer.java
@@ -1,0 +1,71 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation;
+
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.EMPTY_FAILURE_HANDLER;
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.EMPTY_SUCCESS_HANDLER;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class LoginAuthenticationConfigurer <T extends AbstractAuthenticationProcessingFilter>
+    extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final T authenticationFilter;
+
+    private AuthenticationSuccessHandler successHandler;
+    private AuthenticationFailureHandler failureHandler;
+
+    @Override
+    public void init(HttpSecurity builder) {
+    }
+
+    /**
+     * HttpSecurity builder를 사용해 커스텀 인증 필터를 구성하는 메서드입니다.
+     *
+     * @param builder   인증 필터가 추가될 HttpSecurity
+     * */
+    @Override
+    public void configure(HttpSecurity builder) {
+        validateHandler(); // 성공 및 실패 핸들러가 올바르게 설정되었는지 확인
+        setAuthenticationFilter(builder);
+        builder.addFilterBefore(
+            authenticationFilter,
+            UsernamePasswordAuthenticationFilter.class
+        ); //UsernamePasswordAuthenticationFilter` 앞에 추가되어 Spring Security의 인증 처리 과정에서 우선적으로 동작
+    }
+
+    public LoginAuthenticationConfigurer<T> successHandler(AuthenticationSuccessHandler successHandler) {
+        this.successHandler = successHandler;
+        return this;
+    }
+
+    public LoginAuthenticationConfigurer<T> failureHandler(AuthenticationFailureHandler failureHandler) {
+        this.failureHandler = failureHandler;
+        return this;
+    }
+
+    private void validateHandler() {
+        if (successHandler == null) {
+            throw new IllegalStateException(EMPTY_SUCCESS_HANDLER.getMessage());
+        }
+
+        if (failureHandler == null) {
+            throw new IllegalStateException(EMPTY_FAILURE_HANDLER.getMessage());
+        }
+    }
+
+    private void setAuthenticationFilter(HttpSecurity builder) {
+
+        //`HttpSecurity` 빌더로부터 공유된 `AuthenticationManager` 객체를 가져와 `authenticationFilter`에 설정합니다.
+        authenticationFilter.setAuthenticationManager(builder.getSharedObject(AuthenticationManager.class));
+        authenticationFilter.setAuthenticationSuccessHandler(successHandler);
+        authenticationFilter.setAuthenticationFailureHandler(failureHandler);
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LoginAuthenticationFailureHandler.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LoginAuthenticationFailureHandler.java
@@ -1,0 +1,53 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation;
+
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.LOGIN_FAIL;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.feedlink.api.feedlink_api.global.common.CommonResponse;
+import com.feedlink.api.feedlink_api.global.security.exception.InvalidAuthenticationArgumentException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+@Slf4j
+@RequiredArgsConstructor
+public class LoginAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException exception
+    ) throws IOException {
+        HttpStatus httpStatus;
+        CommonResponse<Void> commonResponse;
+
+        if (exception instanceof InvalidAuthenticationArgumentException) {
+            httpStatus = HttpStatus.BAD_REQUEST;
+            commonResponse = CommonResponse.fail(exception.getMessage());
+        } else {
+            httpStatus = HttpStatus.UNAUTHORIZED;
+            if (exception instanceof BadCredentialsException) {
+                commonResponse = CommonResponse.fail(LOGIN_FAIL.getMessage());
+            } else {
+                commonResponse = CommonResponse.fail(exception.getMessage());
+            }
+        }
+
+        response.setStatus(httpStatus.value());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), commonResponse);
+    }
+}
+

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LoginAuthenticationFilter.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LoginAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation;
+
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.INVALID_INPUT_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.feedlink.api.feedlink_api.domain.member.dto.MemberLoginRequest;
+import com.feedlink.api.feedlink_api.global.security.exception.InvalidAuthenticationArgumentException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Slf4j
+public class LoginAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER =
+        new AntPathRequestMatcher("/api/members/login", "POST");
+
+    private final ObjectMapper objectMapper;
+
+    public LoginAuthenticationFilter(ObjectMapper objectMapper) {
+        super(DEFAULT_ANT_PATH_REQUEST_MATCHER);
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(
+        HttpServletRequest request,
+        HttpServletResponse response
+    ) throws AuthenticationException, InvalidAuthenticationArgumentException {
+        MemberLoginRequest loginRequest = getLoginInfo(request);
+        String email = loginRequest.getEmail();
+        String password = loginRequest.getPassword();
+        log.info("Login email = {} / password = {}", email, password);
+
+        UsernamePasswordAuthenticationToken authRequest =
+            UsernamePasswordAuthenticationToken.unauthenticated(email, password);
+        return getAuthenticationManager().authenticate(authRequest);
+    }
+
+    private MemberLoginRequest getLoginInfo(HttpServletRequest request)
+        throws InvalidAuthenticationArgumentException {
+        try {
+            return objectMapper.readValue(request.getReader(), MemberLoginRequest.class);
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new InvalidAuthenticationArgumentException(INVALID_INPUT_VALUE);
+        }
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LoginAuthenticationSuccessHandler.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LoginAuthenticationSuccessHandler.java
@@ -1,0 +1,44 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.feedlink.api.feedlink_api.global.common.CommonResponse;
+import com.feedlink.api.feedlink_api.global.security.autheniation.dto.AuthenticationToken;
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+@Slf4j
+@RequiredArgsConstructor
+public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private static final int TOKEN_REFRESH_INTERVAL = 24;
+    private final ObjectMapper objectMapper;
+    private final TokenService tokenService;
+
+    @Override
+    public void onAuthenticationSuccess(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Authentication authentication
+    ) throws IOException {
+        String memberId = authentication.getName();
+        log.info("Authentication memberID = {}", memberId);
+
+        String randomToken = UUID.randomUUID().toString();
+        AuthenticationToken authenticationToken = tokenService.generatedToken(randomToken, memberId);
+
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), CommonResponse.ok(authenticationToken));
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LogoutTokenHandler.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LogoutTokenHandler.java
@@ -1,0 +1,44 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.feedlink.api.feedlink_api.global.error.ErrorCode;
+import com.feedlink.api.feedlink_api.global.exception.CustomException;
+import com.feedlink.api.feedlink_api.global.security.autheniation.dto.LogoutRequest;
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+@Slf4j
+@RequiredArgsConstructor
+public class LogoutTokenHandler implements LogoutHandler {
+
+    private final ObjectMapper objectMapper;
+    private final TokenService tokenService;
+
+    @Override
+    public void logout(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Authentication authentication
+    ) {
+        LogoutRequest logoutRequest = getLogoutInfo(request);
+        log.info("Logout Info = {}", logoutRequest);
+
+        tokenService.removeRefreshToken(logoutRequest.getRefreshToken());
+        tokenService.addBlackList(logoutRequest.getAccessToken());
+    }
+
+    private LogoutRequest getLogoutInfo(HttpServletRequest request) {
+        try {
+            return objectMapper.readValue(request.getReader(), LogoutRequest.class);
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+}
+

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LogoutTokenSuccessHandler.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/LogoutTokenSuccessHandler.java
@@ -1,0 +1,31 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.feedlink.api.feedlink_api.global.common.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+@RequiredArgsConstructor
+public class LogoutTokenSuccessHandler implements LogoutSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onLogoutSuccess(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Authentication authentication
+    ) throws IOException {
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), CommonResponse.ok("로그아웃 되었습니다.",null));
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/dto/AuthenticationToken.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/dto/AuthenticationToken.java
@@ -1,0 +1,28 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation.dto;
+
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.dto.Token;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthenticationToken {
+
+    private String grantType;
+
+    private String refreshToken;
+
+    private Long expiresIn;
+
+    private String accessToken;
+    public static AuthenticationToken of(Token token) {
+        return AuthenticationToken.builder()
+            .grantType(token.getGrantType())
+            .refreshToken(token.getRefreshToken())
+            .accessToken(token.getAccessToken())
+            .expiresIn(token.getAccessTokenExpired())
+            .build();
+    }
+}
+
+

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/dto/LogoutRequest.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/dto/LogoutRequest.java
@@ -1,0 +1,27 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation.dto;
+
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.EMPTY_ACCESS_TOKEN;
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.EMPTY_REFRESH_TOKEN;
+
+import com.feedlink.api.feedlink_api.global.exception.CustomException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+@Getter
+@NoArgsConstructor
+public class LogoutRequest {
+    private String refreshToken;
+    private String accessToken;
+
+    public LogoutRequest(String refreshToken, String accessToken) {
+        if (!StringUtils.hasText(refreshToken)) {
+            throw new CustomException(EMPTY_REFRESH_TOKEN);
+        }
+        if (!StringUtils.hasText(accessToken)) {
+            throw new CustomException(EMPTY_ACCESS_TOKEN);
+        }
+
+        this.refreshToken = refreshToken;
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/TokenProvider.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/TokenProvider.java
@@ -1,0 +1,139 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation.token;
+
+import static io.jsonwebtoken.SignatureAlgorithm.HS256;
+import static org.springframework.security.config.Elements.JWT;
+
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.dto.Token;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class TokenProvider {
+    private static final int MILLISECONDS_TO_SECONDS = 1000;
+    private static final int TOKEN_REFRESH_INTERVAL = 24;
+    private static final String TOKEN_CLAIM_KEY = "username";
+    private static final String TOKEN_EXPIRATION_KEY = "exp";
+
+    private final Key key;
+    private final String grantType;
+    private final Long accessTokenExpiredTime;
+    private final Long refreshTokenExpiredTime;
+
+    public TokenProvider(
+        @Value("${jwt.secret}") String secretKey,
+        @Value("${jwt.grant-type}") String grantType,
+        @Value("${jwt.token-validate-in-seconds}") Long tokenValidateInSeconds
+    ) {
+        this.key = getSecretKey(secretKey);
+        this.grantType = grantType;
+        this.accessTokenExpiredTime = tokenValidateInSeconds;
+        this.refreshTokenExpiredTime = tokenValidateInSeconds * TOKEN_REFRESH_INTERVAL;
+    }
+
+    /** Token 생성 */
+    public Token generateToken(String randomToken, String username) {
+        return Token.builder()
+            .grantType(grantType)
+            .refreshToken(createRefreshToken(randomToken))
+            .refreshTokenExpired(refreshTokenExpiredTime)
+            .accessToken(createAccessToken(username))
+            .accessTokenExpired(accessTokenExpiredTime)
+            .build();
+    }
+
+    public String getUsername(String token)
+        throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
+        Claims claims = getClaims(token);
+        String claim = claims.get(TOKEN_CLAIM_KEY, String.class);
+        if (Objects.isNull(claim)) {
+            throw new IllegalArgumentException();
+        }
+        return claim;
+    }
+
+    public Long getExpiration(String token)
+        throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
+        Claims claims = getClaims(token);
+        return claims.get(TOKEN_EXPIRATION_KEY, Long.class);
+    }
+
+    public String getSubject(String token)
+        throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
+        Claims claims = getClaims(token);
+        return claims.getSubject();
+    }
+
+    private String createAccessToken(String username) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + accessTokenExpiredTime * MILLISECONDS_TO_SECONDS);
+
+        return Jwts.builder()
+            .setSubject(username)
+            .setIssuedAt(now)
+            .setExpiration(expireDate)
+            .claim(TOKEN_CLAIM_KEY, username)
+            .signWith(key, HS256)
+            .compact();
+    }
+
+    private String createRefreshToken(String randomToken) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + refreshTokenExpiredTime * MILLISECONDS_TO_SECONDS);
+
+        return Jwts.builder()
+            .setHeader(createHeader())
+            .setSubject(randomToken)
+            .setIssuedAt(now)
+            .setExpiration(expireDate)
+            .signWith(key, HS256)
+            .compact();
+    }
+
+    public Token generateTokenWithExistingRefreshToken(String username, String existingRefreshToken) {
+        return Token.builder()
+            .grantType(grantType)
+            .refreshToken(existingRefreshToken)
+            .refreshTokenExpired(getExpiration(existingRefreshToken))
+            .accessToken(createAccessToken(username))
+            .accessTokenExpired(accessTokenExpiredTime)
+            .build();
+    }
+
+    private SecretKey getSecretKey(String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /** JWT의 헤더(Header)를 생성 */
+    private Map<String, Object> createHeader() {
+        Map<String, Object> header = new HashMap<>();
+        header.put("alg", HS256.getValue());
+        header.put("typ", JWT);
+        return header;
+    }
+
+    /** 주어진 JWT 토큰에서 클레임(Claims)을 추출 */
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/TokenProvider.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/TokenProvider.java
@@ -42,8 +42,8 @@ public class TokenProvider {
     ) {
         this.key = getSecretKey(secretKey);
         this.grantType = grantType;
-        this.accessTokenExpiredTime = tokenValidateInSeconds;
-        this.refreshTokenExpiredTime = tokenValidateInSeconds * TOKEN_REFRESH_INTERVAL;
+        this.accessTokenExpiredTime = tokenValidateInSeconds; //accessToken 만료시간 3시간
+        this.refreshTokenExpiredTime = tokenValidateInSeconds * TOKEN_REFRESH_INTERVAL; //72시간
     }
 
     /** Token 생성 */

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/TokenService.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/TokenService.java
@@ -1,0 +1,166 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation.token;
+
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.EXPIRED_TOKEN;
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.INVALID_TOKEN;
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.SAVE_REFRESH_TOKEN_FAILED;
+
+import com.feedlink.api.feedlink_api.global.exception.CustomException;
+import com.feedlink.api.feedlink_api.global.security.exception.InvalidJwtException;
+import com.feedlink.api.feedlink_api.global.security.exception.SaveTokenException;
+import com.feedlink.api.feedlink_api.global.redis.RedisService;
+import com.feedlink.api.feedlink_api.global.security.autheniation.dto.AuthenticationToken;
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.dto.RefreshToken;
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.dto.Token;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenService {
+    public static final String REDIS_REFERS_TOKEN_PREFIX = "RefreshToken:";
+    public static final String REDIS_BLACK_LIST_PREFIX = "BlackList:";
+    public static final String BLACK_LIST_DEFAULT_VALUE = "Logout";
+    public static final int VALID_MINIMUM_TIME = 0;
+
+    private final TokenProvider tokenProvider;
+    private final RedisService redisService;
+
+    /**
+     * refreshToken을 이용하여 새로운 accessToken을 발급 받습니다.
+     * refreshToken에서 claim을 추출해 redis에 저장된 token과 같은지 비교합니다.
+     * 비교한 값이 같다면 새로운 accessToken를 반환합니다.
+     *
+     * @param refreshToken refreshToken
+     * @param accessToken accessToken
+     *
+     * @return authenticationToken.getAccessToken()
+     * */
+    public String reissueToken(String refreshToken, String accessToken) {
+        try {
+            String randomToken = tokenProvider.getSubject(refreshToken);
+            log.info("Fetch randomToken = [{}]", randomToken);
+
+            RefreshToken token = redisService.get(REDIS_REFERS_TOKEN_PREFIX + randomToken, RefreshToken.class)
+                .orElseThrow(() -> new CustomException(INVALID_TOKEN));
+            log.info("Fetch memberId = [{}]", token.getEmail());
+
+            if (!refreshToken.equals(token.getRefreshToken())) {
+                throw new CustomException(INVALID_TOKEN);
+            }
+
+            addBlackList(accessToken);
+            AuthenticationToken authenticationToken = generateNewAccessToken(token.getEmail(), refreshToken);
+            return authenticationToken.getAccessToken();
+        } catch (ExpiredJwtException e) {
+            log.info("[{}] 이미 만료된 토큰입니다.", refreshToken);
+            throw new CustomException(EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+    }
+
+    /**
+     * 새로운 인증토큰을 생성합니다.
+     * 인증토큰 생성 후 refreshToken를 새로 생성해 redis에 저장합니다.
+     *
+     * @param randomToken randomToken
+     * @param memberId 회원 ID
+     *
+     * @return AuthenticationToken
+     * */
+    public AuthenticationToken generatedToken(String randomToken, String memberId) {
+        Token token = tokenProvider.generateToken(randomToken, memberId);
+        try {
+            RefreshToken refreshToken = createRefreshToken(memberId, token);
+            redisService.set(REDIS_REFERS_TOKEN_PREFIX + randomToken, refreshToken, token.getRefreshTokenExpired());
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new SaveTokenException(SAVE_REFRESH_TOKEN_FAILED);
+        }
+
+        return AuthenticationToken.of(token);
+    }
+
+    /**
+     * token에 저장된 회원 정보를 조회합니다.
+     *
+     * @param token 토큰
+     *
+     * @return 토큰에 저장된 회원정보
+     * */
+    public String getUsername(String token)
+        throws ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException {
+        return tokenProvider.getUsername(token);
+    }
+
+    /**
+     * redis에 저장된 refreshToken를 삭제합니다.
+     *
+     * @param refreshToken refreshToken
+     * */
+    public void removeRefreshToken(String refreshToken) {
+        try {
+            String randomToken = tokenProvider.getSubject(refreshToken);
+            log.info("Remove randomToken = [{}]", randomToken);
+
+            if (redisService.delete(REDIS_REFERS_TOKEN_PREFIX + randomToken)) {
+                log.info("[{}] RefreshToken 삭제 성공", randomToken);
+            }
+        } catch (ExpiredJwtException e) {
+            log.info("[{}] 이미 만료된 토큰입니다.", refreshToken);
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+            throw new InvalidJwtException(INVALID_TOKEN, e);
+        }
+    }
+
+    /**
+     * accessToken를 redis의 블랙리스트로 저장합나디.
+     *
+     * @param accessToken  저장할 accessToken
+     * */
+    public void addBlackList(String accessToken) {
+        try {
+            long expiredIn = tokenProvider.getExpiration(accessToken);
+            long validTime = expiredIn - Instant.now().getEpochSecond();
+
+            log.info("[{}] AccessToken의 남은 만료 시간은 {}초 입니다.", tokenProvider.getUsername(accessToken), validTime);
+            if (validTime > VALID_MINIMUM_TIME) {
+                redisService.set(REDIS_BLACK_LIST_PREFIX + accessToken, BLACK_LIST_DEFAULT_VALUE, validTime);
+            }
+        } catch (ExpiredJwtException e) {
+            log.info("[{}] 이미 만료된 토큰입니다.", accessToken);
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+            throw new InvalidJwtException(INVALID_TOKEN, e);
+        }
+    }
+
+    public boolean isBlackListToken(String token) {
+        return redisService.get(REDIS_BLACK_LIST_PREFIX + token, String.class).isPresent();
+    }
+
+    private RefreshToken createRefreshToken(String email, Token token) {
+        return RefreshToken.builder()
+            .email(email)
+            .refreshToken(token.getRefreshToken())
+            .build();
+    }
+    /**
+     * 회원 정보와 existingRefreshToken로 새로운 토큰을 생성합니다.
+     *
+     * @param username      회원정보
+     * @param existingRefreshToken 기존에 존재하던 existingRefreshToken
+     *
+     * @return 새로 생성된 인증토큰
+     * */
+    private AuthenticationToken generateNewAccessToken(String username, String existingRefreshToken) {
+        Token token = tokenProvider.generateTokenWithExistingRefreshToken(username, existingRefreshToken);
+        return AuthenticationToken.of(token);
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/dto/RefreshToken.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/dto/RefreshToken.java
@@ -1,0 +1,20 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation.token.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+
+    private String email;
+
+    private String refreshToken;
+
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/dto/Token.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/autheniation/token/dto/Token.java
@@ -1,0 +1,27 @@
+package com.feedlink.api.feedlink_api.global.security.autheniation.token.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Token {
+
+    private String grantType;
+
+    private String refreshToken;
+
+    private Long refreshTokenExpired;
+
+    private String accessToken;
+
+    private Long accessTokenExpired;
+
+}
+

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/SecurityAccessDeniedHandler.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/SecurityAccessDeniedHandler.java
@@ -1,0 +1,28 @@
+package com.feedlink.api.feedlink_api.global.security.authorization;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+@Slf4j
+public class SecurityAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException
+    ) throws IOException {
+        log.error("[ERROR] AccessDeniedHandler = {}", accessDeniedException.getMessage(), accessDeniedException);
+
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+        response.sendError(FORBIDDEN.value());
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/SecurityAuthenticationEntryPoint.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/SecurityAuthenticationEntryPoint.java
@@ -1,0 +1,49 @@
+package com.feedlink.api.feedlink_api.global.security.authorization;
+
+import static com.feedlink.api.feedlink_api.global.security.authorization.SecurityErrorCode.ERROR_KEY;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.feedlink.api.feedlink_api.global.common.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+@Slf4j
+@RequiredArgsConstructor
+public class SecurityAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException
+    ) throws IOException {
+        log.error("[ERROR] AuthenticationEntryPoint = {}", authException.getMessage());
+
+        Object attribute = request.getAttribute(ERROR_KEY);
+        if (Objects.isNull(attribute)) {
+            sendErrorResponse(response, CommonResponse.fail(authException.getMessage()));
+            return;
+        }
+
+        SecurityErrorCode code = (SecurityErrorCode) attribute;
+        sendErrorResponse(response, CommonResponse.fail(code.getMessage(), code.getCode()));
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, CommonResponse<?> commonResponse)
+        throws IOException {
+        response.setStatus(UNAUTHORIZED.value());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), commonResponse);
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/SecurityErrorCode.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/SecurityErrorCode.java
@@ -1,0 +1,17 @@
+package com.feedlink.api.feedlink_api.global.security.authorization;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SecurityErrorCode {
+
+    TOKEN_EXPIRED("0001", "만료된 토큰입니다."),
+    ;
+
+    public static final String ERROR_KEY = "tokenError";
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/TokenAuthorityConfigurer.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/TokenAuthorityConfigurer.java
@@ -1,0 +1,28 @@
+package com.feedlink.api.feedlink_api.global.security.authorization;
+
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+@RequiredArgsConstructor
+public class TokenAuthorityConfigurer extends
+    SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final TokenService tokenService;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    public void init(HttpSecurity builder) {
+    }
+
+    @Override
+    public void configure(HttpSecurity builder) {
+        builder.addFilterBefore(
+            new TokenAuthorizationFilter(tokenService, userDetailsService),
+            AuthorizationFilter.class
+        );
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/TokenAuthorizationFilter.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/authorization/TokenAuthorizationFilter.java
@@ -1,0 +1,95 @@
+package com.feedlink.api.feedlink_api.global.security.authorization;
+
+import static com.feedlink.api.feedlink_api.global.error.ErrorCode.INVALID_TOKEN;
+import static com.feedlink.api.feedlink_api.global.security.authorization.SecurityErrorCode.ERROR_KEY;
+import static com.feedlink.api.feedlink_api.global.security.authorization.SecurityErrorCode.TOKEN_EXPIRED;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.feedlink.api.feedlink_api.global.security.autheniation.token.TokenService;
+import com.feedlink.api.feedlink_api.global.security.exception.InvalidJwtException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TokenAuthorizationFilter extends OncePerRequestFilter {
+
+    private static final String GRANT_TYPE = "Bearer ";
+
+    private final TokenService tokenService;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+        @NonNull HttpServletRequest request,
+        @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        log.info("requestURI = {}", request.getRequestURI());
+
+        String authorization = getAuthorization(request);
+        if (isValidToken(authorization)) {
+            String token = authorization.substring(GRANT_TYPE.length());
+            log.info("accessToken = {}", token);
+
+            if (tokenService.isBlackListToken(token)) {
+                throw new InvalidJwtException(INVALID_TOKEN);
+            }
+
+            try {
+                String username = tokenService.getUsername(token);
+                log.info("Authority username = {}", username);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                Authentication authenticated = createAuthentication(userDetails);
+                setSecurityContext(authenticated);
+            } catch (ExpiredJwtException e) {
+                request.setAttribute(ERROR_KEY, TOKEN_EXPIRED);
+            } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+                throw new InvalidJwtException(INVALID_TOKEN, e);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getAuthorization(HttpServletRequest request) {
+        return request.getHeader(AUTHORIZATION);
+    }
+
+    private boolean isValidToken(String token) {
+        return StringUtils.hasText(token) && token.startsWith(GRANT_TYPE);
+    }
+
+    private UsernamePasswordAuthenticationToken createAuthentication(UserDetails userDetails) {
+        return UsernamePasswordAuthenticationToken.authenticated(
+            userDetails,
+            userDetails.getPassword(),
+            userDetails.getAuthorities()
+        );
+    }
+
+    private void setSecurityContext(Authentication authenticated) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authenticated);
+        SecurityContextHolder.setContext(context);
+    }
+}
+

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/exception/InvalidAuthenticationArgumentException.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/exception/InvalidAuthenticationArgumentException.java
@@ -1,0 +1,10 @@
+package com.feedlink.api.feedlink_api.global.security.exception;
+
+import com.feedlink.api.feedlink_api.global.error.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidAuthenticationArgumentException extends AuthenticationException {
+    public InvalidAuthenticationArgumentException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/exception/InvalidJwtException.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/exception/InvalidJwtException.java
@@ -1,0 +1,15 @@
+package com.feedlink.api.feedlink_api.global.security.exception;
+
+import com.feedlink.api.feedlink_api.global.error.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidJwtException extends AuthenticationException {
+
+    public InvalidJwtException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+
+    public InvalidJwtException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+    }
+}

--- a/src/main/java/com/feedlink/api/feedlink_api/global/security/exception/SaveTokenException.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/global/security/exception/SaveTokenException.java
@@ -1,0 +1,12 @@
+package com.feedlink.api.feedlink_api.global.security.exception;
+
+import com.feedlink.api.feedlink_api.global.error.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
+
+public class SaveTokenException extends AuthenticationException {
+
+    public SaveTokenException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,12 @@ spring:
       name: admin
       password: admin
 
+# JWT 설정
+jwt:
+  secret: 411f78115cf6011681137d338b0eff4dce52ae9dcfbb40be18309729177e0380
+  grant-type: Bearer
+  token-validate-in-seconds : 10800
+
 # Springdoc OpenAPI 설정
 springdoc:
   api-docs:


### PR DESCRIPTION
- 이메일, 비밀번호 입력하여 로그인 시 refreshToken, accessToken 발급
- refreshToken, accessToken requestBody에 전송 시 로그아웃 가능
- POSTMAN 기준 Authorization- Bearer Token : accessToken 전송 시 @AuthenticationPrincipal 를 이용해 Member 조회 가능
- accessToken 만료 시 requestBody {refreshToken, accessToken}  -> accessToken 재발급
---
- gradle : redis, jwt 의존성 추가
- application.yml : jwt secretkey. 추가 (보안상 큰 문제는 없어서 일단 바로 올렸으나, 저장 방법 논의 필요!)
---
- @hongggs 님 코드랑 충돌 날 것 같아서 merge할때 주의 필요!!!!