### PR TITLE
Fix: #9 Dockerfile 이미지 JDK 버전 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:11-alpine-jdk
+FROM amazoncorretto:17-alpine-jdk
 ARG JAR_FILE=build/libs/*.jar
 ARG PROFILES
 ARG ENV


### PR DESCRIPTION
이미지 내에서 지정한 JDK 버전이 11로 되어 있어 수정했습니다.