### PR TITLE
Chore: #1 Add Swagger 문서화 for 회원가입 기능

### DIFF
--- a/src/main/java/com/feedlink/api/feedlink_api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/member/controller/MemberController.java
@@ -6,6 +6,13 @@ import com.feedlink.api.feedlink_api.domain.member.dto.MemberVerificationRequest
 import com.feedlink.api.feedlink_api.domain.member.service.MemberService;
 import com.feedlink.api.feedlink_api.domain.security.PrincipalDetails;
 import com.feedlink.api.feedlink_api.global.common.CommonResponse;
+import com.feedlink.api.feedlink_api.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +39,160 @@ public class MemberController {
      * @param request 회원가입 요청을 담은 DTO 객체
      * @return 회원가입 결과를 담은 CommonResponse 객체와 HTTP 상태 코드
      */
+    @Operation(
+        summary = "회원가입 요청",
+        description = "사용자가 이메일, 비밀번호, 계정 정보를 제공하여 회원가입을 요청합니다.",
+        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = MemberSignupRequest.class),
+                examples = @ExampleObject(
+                    value = """
+                {
+                  "memberEmail": "example@domain.com",
+                  "memberPwd": "Password123!",
+                  "memberAccount": "exampleUser"
+                }
+                """
+                )
+            )
+        )
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "회원가입 완료.",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CommonResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                {
+                  "httpStatus": "CREATED",
+                  "message": "회원가입이 성공적으로 완료되었습니다.",
+                  "data": null
+                }
+                """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "중복된 이메일이나 계정을 입력한 경우",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "이미 존재하는 이메일인 경우",
+                        summary = "EMAIL_ALREADY_EXISTS",
+                        value = """
+                    {
+                      "errorCode": "EMAIL_ALREADY_EXISTS",
+                      "statusCode": 409,
+                      "httpStatus": "CONFLICT",
+                      "message": "이미 존재하는 이메일입니다."
+                    }
+                    """
+                    ),
+                    @ExampleObject(
+                        name = "이미 존재하는 계정인 경우",
+                        summary = "ACCOUNT_ALREADY_EXISTS",
+                        value = """
+                    {
+                      "errorCode": "ACCOUNT_ALREADY_EXISTS",
+                      "statusCode": 409,
+                      "httpStatus": "CONFLICT",
+                      "message": "이미 존재하는 계정입니다."
+                    }
+                    """
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "정책에 맞지않는 입력 값을 받은 경우",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "비밀번호 정책에 맞지 않는 경우",
+                        summary = "PASSWORD_VIOLATES_POLICY",
+                        value = """
+                    {
+                      "errorCode": "PASSWORD_VIOLATES_POLICY",
+                      "statusCode": 400,
+                      "httpStatus": "BAD_REQUEST",
+                      "message": "비밀번호 정책에 맞지 않습니다."
+                    }
+                    """
+                    ),
+                    @ExampleObject(
+                        name = "비밀번호가 10자 미만인 경우",
+                        summary = "PASSWORD_TOO_SHORT",
+                        value = """
+                    {
+                      "errorCode": "PASSWORD_TOO_SHORT",
+                      "statusCode": 400,
+                      "httpStatus": "BAD_REQUEST",
+                      "message": "비밀번호는 최소 10자 이상이어야 합니다."
+                    }
+                    """
+                    ),
+                    @ExampleObject(
+                        name = "통상적으로 자주 사용되는 비밀번호인 경우",
+                        summary = "PASSWORD_TOO_COMMON",
+                        value = """
+                    {
+                      "errorCode": "PASSWORD_TOO_COMMON",
+                      "statusCode": 400,
+                      "httpStatus": "BAD_REQUEST",
+                      "message": "통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다."
+                    }
+                    """
+                    ),
+                    @ExampleObject(
+                        name = "숫자, 문자, 특수문자 중 2가지 이상을 포함하지 않은 경우",
+                        summary = "PASSWORD_LACKS_VARIETY",
+                        value = """
+                    {
+                      "errorCode": "PASSWORD_LACKS_VARIETY",
+                      "statusCode": 400,
+                      "httpStatus": "BAD_REQUEST",
+                      "message": "숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다.."
+                    }
+                    """
+                    ),
+                    @ExampleObject(
+                        name = "비밀번호가 다른 개인 정보와 유사할 경우",
+                        summary = "PASSWORD_SIMILAR_TO_PERSONAL_INFO",
+                        value = """
+                    {
+                      "errorCode": "PASSWORD_SIMILAR_TO_PERSONAL_INFO",
+                      "statusCode": 400,
+                      "httpStatus": "BAD_REQUEST",
+                      "message": "비밀번호는 다른 개인 정보와 유사할 수 없습니다."
+                    }
+                    """
+                    ),
+                    @ExampleObject(
+                        name = "3회 이상 연속되는 문자는 사용한 경우",
+                        summary = "PASSWORD_HAS_SEQUENTIAL_CHARS",
+                        value = """
+                    {
+                      "errorCode": "PASSWORD_HAS_SEQUENTIAL_CHARS",
+                      "statusCode": 400,
+                      "httpStatus": "BAD_REQUEST",
+                      "message": "3회 이상 연속되는 문자는 사용할 수 없습니다."
+                    }
+                    """
+                    ),
+                }
+            )
+        )
+    })
     @PostMapping("/signup")
     public ResponseEntity<CommonResponse<String>> signup(@Valid @RequestBody MemberSignupRequest request) {
         CommonResponse<String> response = memberService.signup(request);


### PR DESCRIPTION
- 회원가입 요청에 대한 API 설명 추가 (`/signup` 엔드포인트)
- 중복된 이메일과 계정에 대한 409 응답 예시 추가
- 성공적인 회원가입에 대한 201 응답 예시 추가
- 부적절한 입력에 대한 400 응답 예시 추가