### PR TITLE
Chore: #2 Add Swagger 문서화 for 가입인증 기능

### DIFF
--- a/src/main/java/com/feedlink/api/feedlink_api/domain/member/controller/MemberController.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/member/controller/MemberController.java
@@ -206,6 +206,88 @@ public class MemberController {
      * @param request 회원가입 승인 요청을 담은 DTO 객체
      * @return 계정 활성화 결과를 담은 CommonResponse 객체와 HTTP 상태 코드
      */
+    @Operation(
+        summary = "회원가입 승인 요청",
+        description = "사용자가 인증 코드를 통해 계정을 활성화합니다.",
+        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = MemberVerificationRequest.class),
+                examples = @ExampleObject(
+                    value = """
+                {
+                  "memberAccount": "exampleUser",
+                  "memberPwd": "Password123!",
+                  "memberCode": "516449"
+                }
+                """
+                )
+            )
+        )
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "계정이 성공적으로 활성화된 경우",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CommonResponse.class),
+                examples = @ExampleObject(
+                    value = """
+                {
+                  "httpStatus": "OK",
+                  "message": "계정이 성공적으로 활성화되었습니다.",
+                  "data": null
+                }
+                """
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "적절하지 않은 값을 입력 받은 경우",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "비밀번호가 틀린 경우",
+                        summary = "PASSWORD_INVALID",
+                        value = """
+                    {
+                      "errorCode": "PASSWORD_INVALID",
+                      "statusCode": 400,
+                      "httpStatus": "BAD_REQUEST",
+                      "message": "비밀번호가 올바르지 않습니다."
+                    }
+                    """
+                    ),
+                    @ExampleObject(
+                        name = "인증코드가 틀린 경우",
+                        summary = "INVALID_MEMBER_CODE",
+                        value = """
+                    {
+                      "errorCode": "INVALID_MEMBER_CODE",
+                      "statusCode": 400,
+                      "httpStatus": "BAD_REQUEST",
+                      "message": "인증 코드가 올바르지 않습니다."
+                    }"""
+                    ),
+                    @ExampleObject(
+                        name = "계정이 존재하지 않는 경우",
+                        summary = "INVALID_MEMBER_CODE",
+                        value = """
+                    {
+                      "errorCode": "USER_NOT_FOUND",
+                      "statusCode": 400,
+                      "httpStatus": "BAD_REQUEST",
+                      "message": "사용자를 찾을 수 없습니다."
+                    }"""
+                    )
+                }
+            )
+        )
+    })
     @PostMapping("/verify")
     public ResponseEntity<CommonResponse<String>> verifyMember(@Valid @RequestBody MemberVerificationRequest request) {
         CommonResponse<String> response = memberService.verifyMember(request);


### PR DESCRIPTION
- 가입 인증 요청에 대한 API 설명 추가 (`/verify` 엔드포인트)
- 잘못된 계정, 인증 코드, 비밀번호에 대한 400 응답 예시 추가