### PR TITLE
Feat: #4 게시물 목록 로그인 연동

### DIFF
--- a/src/main/java/com/feedlink/api/feedlink_api/domain/post/controller/PostController.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/post/controller/PostController.java
@@ -4,9 +4,11 @@ import com.feedlink.api.feedlink_api.domain.post.dto.PostDTO;
 import com.feedlink.api.feedlink_api.domain.post.entity.Post;
 import com.feedlink.api.feedlink_api.domain.post.enums.PostType;
 import com.feedlink.api.feedlink_api.domain.post.service.PostService;
+import com.feedlink.api.feedlink_api.domain.security.PrincipalDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,15 +23,17 @@ public class PostController {
 
     @GetMapping
     public ResponseEntity<Page<PostDTO>> getAllPosts(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
         @RequestParam(required = false) String hashtag,
         @RequestParam(required = false) PostType type,
-        @RequestParam(defaultValue = "postCreateTime") String orderBy,
+        @RequestParam(defaultValue = "created_at") String orderBy,
         @RequestParam(defaultValue = "title,content") String searchBy,
         @RequestParam(required = false) String search,
         @RequestParam(defaultValue = "10") int pageCount,
         @RequestParam(defaultValue = "0") int page
     ) {
-        Page<PostDTO> posts = postService.getAllPosts(hashtag, type, orderBy, searchBy, search, pageCount, page);
+        String memberAccount = principalDetails.getMember().getMemberAccount();
+        Page<PostDTO> posts = postService.getAllPosts(memberAccount, hashtag, type, orderBy, searchBy, search, pageCount, page);
         return ResponseEntity.ok(posts);
     }
 

--- a/src/main/java/com/feedlink/api/feedlink_api/domain/post/service/PostService.java
+++ b/src/main/java/com/feedlink/api/feedlink_api/domain/post/service/PostService.java
@@ -4,10 +4,13 @@ import com.feedlink.api.feedlink_api.domain.post.dto.PostDTO;
 import com.feedlink.api.feedlink_api.domain.post.entity.Post;
 import com.feedlink.api.feedlink_api.domain.post.enums.PostType;
 import com.feedlink.api.feedlink_api.domain.post.repository.PostRepository;
+import com.feedlink.api.feedlink_api.global.error.ErrorCode;
+import com.feedlink.api.feedlink_api.global.exception.CustomException;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -22,14 +25,31 @@ public class PostService {
     @Autowired
     private PostRepository postRepository;
 
+    private static final Map<String, String> SORT_FIELDS_MAPPING = Map.of(
+        "created_at", "postCreateTime",
+        "updated_at", "postUpdateTime",
+        "like_count", "postLikeCnt",
+        "share_count", "postShareCnt",
+        "view_count", "postViewCnt"
+    );
+
+    private Sort createSort(String orderBy, String sortDirection) {
+        String field = SORT_FIELDS_MAPPING.getOrDefault(orderBy, "postCreateTime");
+        Sort.Direction direction = sortDirection != null && sortDirection.equalsIgnoreCase("asc")
+            ? Sort.Direction.ASC
+            : Sort.Direction.DESC;
+
+        return Sort.by(direction, field);
+    }
+
     @Transactional
-    public Page<PostDTO> getAllPosts(String hashtag, PostType type, String orderBy, String searchBy, String search, int pageCount, int page) {
+    public Page<PostDTO> getAllPosts(String memberAccount, String hashtag, PostType type, String orderBy, String searchBy, String search, int pageCount, int page) {
+        String effectiveHashtag = (hashtag != null) ? hashtag : memberAccount;
+
         Specification<Post> spec = (root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new ArrayList<>();
 
-            if (hashtag != null) {
-                predicates.add(criteriaBuilder.equal(root.join("postHashtagList").join("hashtag").get("hashtagName"), hashtag));
-            }
+            predicates.add(criteriaBuilder.equal(root.join("postHashtagList").join("hashtag").get("hashtagName"), effectiveHashtag));
 
             if (type != null) {
                 predicates.add(criteriaBuilder.equal(root.get("postType"), type));
@@ -50,7 +70,7 @@ public class PostService {
             return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
         };
 
-        Sort sort = Sort.by(Sort.Direction.DESC, orderBy != null ? orderBy : "postCreateTime");
+        Sort sort = createSort(orderBy, "desc");
         Pageable pageable = PageRequest.of(page, pageCount, sort);
 
         Page<Post> posts = postRepository.findAll(spec, pageable);
@@ -60,10 +80,15 @@ public class PostService {
                 .map(postHashtag -> postHashtag.getHashtag().getHashtagName())
                 .collect(Collectors.toList());
 
+            String limitedContent = post.getPostContent();
+            if (limitedContent.length() > 20) {
+                limitedContent = limitedContent.substring(0, 20) + "...";
+            }
+
             return PostDTO.builder()
                 .postId(post.getPostId())
                 .postTitle(post.getPostTitle())
-                .postContent(post.getPostContent())
+                .postContent(limitedContent)
                 .postViewCnt(post.getPostViewCnt())
                 .postLikeCnt(post.getPostLikeCnt())
                 .postShareCnt(post.getPostShareCnt())
@@ -80,7 +105,7 @@ public class PostService {
     @Transactional
     public PostDTO getPostById(Long id) {
         Post post = postRepository.findById(id)
-            .orElseThrow(() -> new RuntimeException("Post not found"));
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT_VALUE));
 
         post.setPostViewCnt(post.getPostViewCnt() + 1);
         postRepository.save(post);


### PR DESCRIPTION
* 게시물 목록 조회 시, 토큰 사용하여 해시태그 default 값 아이디로 지정
* 정렬 기준을 created_at, updated_at, like_count, share_count, view_count로 입력 받게 수정
* 오름차순 , 내림차순 모두 가능하게 구현
   * 오름차순/내림차순 파라미터가 없어서 내림차순으로만 정렬되게 구현, parameter 추가 시 바로 적용 가능
* 게시물 목록에서 내용 20자 까지만 출력 되게 변경
* 잘못된 id로 상세 정보 조회 시 출력되는 error 메시지를 global에 있는 내용으로 수정
* Sort의 경우 따로 함수를 빼며 기존 방식 유지함