### PR TITLE
Chore: #9 Add 설정 파일에 운영 환경 Redis 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -124,6 +124,13 @@ spring:
         show_sql: false
         highlight_sql: false
 
+  # Redis 설정
+  data:
+    redis:
+      host: 15.164.248.177
+      port: 6379
+
+
 # logback 설정
 logging:
   config: classpath:logback-prod.xml


### PR DESCRIPTION
운영 환경에서 애플리케이션의 Docker 사용으로 localhost 대신 운영 환경의 ip, port로 직접 지정했습니다.